### PR TITLE
Replaced usages of `copymem` with `memcpy`

### DIFF
--- a/quickjs/builtin_binding_generator.py
+++ b/quickjs/builtin_binding_generator.py
@@ -147,7 +147,7 @@ static JSValue ${func}(JSContext *ctx, JSValueConst new_target, int argc, JSValu
 					ERR_PRINTS("Length of the ArrayBuffer does not match for ${class}");
 				}
 				tmp.resize(size / sizeof(${element}));
-				copymem(tmp.write().ptr(), buffer, size / sizeof(${element}) * sizeof(${element}));
+				memcpy(tmp.write().ptr(), buffer, size / sizeof(${element}) * sizeof(${element}));
 			}
 		} else if (JS_IsDataView(argv[0])) {
 			JSValue byte_length = JS_GetPropertyStr(ctx, argv[0], "byteLength");
@@ -164,7 +164,7 @@ static JSValue ${func}(JSContext *ctx, JSValueConst new_target, int argc, JSValu
 			JS_FreeValue(ctx, arraybuffer);
 			if (length) {
 				tmp.resize(length / sizeof(${element}));
-				copymem(tmp.write().ptr(), buffer + offset, length / sizeof(${element}) * sizeof(${element}));
+				memcpy(tmp.write().ptr(), buffer + offset, length / sizeof(${element}) * sizeof(${element}));
 			}
 		} else {
 #ifdef DEBUG_METHODS_ENABLED

--- a/quickjs/quickjs_binder.cpp
+++ b/quickjs/quickjs_binder.cpp
@@ -1536,7 +1536,7 @@ Error QuickJSBinder::compile_to_bytecode(const String &p_code, const String &p_f
 		size_t size;
 		if (uint8_t *buf = JS_WriteObject(ctx, &size, module, JS_WRITE_OBJ_BYTECODE | JS_WRITE_OBJ_REFERENCE | JS_WRITE_OBJ_SAB)) {
 			r_bytecode.resize(size);
-			copymem(r_bytecode.ptrw(), buf, size);
+			memcpy(r_bytecode.ptrw(), buf, size);
 			js_free(ctx, buf);
 			JS_FreeValue(ctx, module);
 		} else {

--- a/quickjs/quickjs_builtin_binder.cpp
+++ b/quickjs/quickjs_builtin_binder.cpp
@@ -1011,7 +1011,7 @@ void QuickJSBuiltinBinder::bind_builtin_propties_manually() {
 						PoolByteArray::Read r = ptr->read();
 						CharString cs;
 						cs.resize(ptr->size() + 1);
-						copymem(cs.ptrw(), r.ptr(), ptr->size());
+						memcpy(cs.ptrw(), r.ptr(), ptr->size());
 						cs[ptr->size()] = 0;
 						ret = cs.get_data();
 					}


### PR DESCRIPTION
This replaces usages of `copymem` with `memcpy`.

This makes Godot ECMAScript work with https://github.com/godotengine/godot/pull/48239