### PR TITLE
fix 3.4 build

### DIFF
--- a/ecmascript.cpp
+++ b/ecmascript.cpp
@@ -96,7 +96,7 @@ Error ECMAScript::reload(bool p_keep_state) {
 
 	if (!ecma_class) {
 		err = ERR_PARSE_ERROR;
-		ERR_PRINTS(binder->error_to_string(ecma_err));
+		ERR_PRINT(binder->error_to_string(ecma_err));
 	} else {
 #ifdef TOOLS_ENABLED
 		set_last_modified_time(FileAccess::get_modified_time(script_path));
@@ -426,4 +426,9 @@ void ResourceFormatSaverECMAScriptModule::get_recognized_extensions(const RES &p
 
 bool ResourceFormatSaverECMAScriptModule::recognize(const RES &p_resource) const {
 	return Object::cast_to<ECMAScriptModule>(*p_resource) != NULL;
+}
+
+// 3.4
+bool ECMAScript::inherits_script(const Ref<Script> &p_script) const {
+	return false;
 }

--- a/ecmascript.h
+++ b/ecmascript.h
@@ -63,6 +63,9 @@ public:
 
 	virtual bool is_tool() const;
 	virtual bool is_valid() const;
+	// 3.4
+	bool inherits_script(const Ref<Script> &p_script) const;
+
 
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const;
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;

--- a/ecmascript_language.cpp
+++ b/ecmascript_language.cpp
@@ -312,3 +312,17 @@ ECMAScriptLanguage::ECMAScriptLanguage() {
 ECMAScriptLanguage::~ECMAScriptLanguage() {
 	memdelete(main_binder);
 }
+
+
+// 3.4 控制流关键词
+bool ECMAScriptLanguage::is_control_flow_keyword(String p_keyword) const {
+	return p_keyword == "break" ||
+			p_keyword == "continue" ||
+			p_keyword == "if" ||
+			p_keyword == "else" ||
+			p_keyword == "for" ||
+			p_keyword == "switch" ||
+			p_keyword == "default" ||
+			p_keyword == "return" ||
+			p_keyword == "while";
+}

--- a/ecmascript_language.h
+++ b/ecmascript_language.h
@@ -67,6 +67,9 @@ public:
 	virtual String validate_path(const String &p_path) const { return ""; }
 	virtual Script *create_script() const;
 
+	// 3.4
+	virtual bool is_control_flow_keyword(String p_keywords) const;
+
 	/* TODO */ virtual int find_function(const String &p_function, const String &p_code) const { return -1; }
 	/* TODO */ virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const { return ""; }
 	/* TODO */ virtual Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) { return ERR_UNAVAILABLE; }
@@ -78,7 +81,7 @@ public:
 	/* TODO */ virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) {}
 	/* TODO */ virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) {}
 	/* TODO */ virtual void remove_named_global_constant(const StringName &p_name) {}
-
+	
 	/* MULTITHREAD FUNCTIONS */
 
 	//some VMs need to be notified of thread creation/exiting to allocate a stack

--- a/quickjs/builtin_binding_generator.py
+++ b/quickjs/builtin_binding_generator.py
@@ -144,7 +144,7 @@ static JSValue ${func}(JSContext *ctx, JSValueConst new_target, int argc, JSValu
 			uint8_t *buffer = JS_GetArrayBuffer(ctx, &size, argv[0]);
 			if (size) {
 				if (size % sizeof(${element}) != 0) {
-					ERR_PRINTS("Length of the ArrayBuffer does not match for ${class}");
+					ERR_PRINT("Length of the ArrayBuffer does not match for ${class}");
 				}
 				tmp.resize(size / sizeof(${element}));
 				memcpy(tmp.write().ptr(), buffer, size / sizeof(${element}) * sizeof(${element}));

--- a/quickjs/quickjs_binder.cpp
+++ b/quickjs/quickjs_binder.cpp
@@ -186,7 +186,7 @@ JSValue QuickJSBinder::object_method(JSContext *ctx, JSValueConst this_val, int 
 		if (binder->get_stacks(stacks) == OK) {
 			stack_message = binder->get_backtrace_message(stacks);
 		}
-		ERR_PRINTS(obj->get_class() + "." + mb->get_name() + ENDL + err_message + ENDL + stack_message);
+		ERR_PRINT(obj->get_class() + "." + mb->get_name() + ENDL + err_message + ENDL + stack_message);
 		JS_FreeValue(ctx, ret);
 		ret = JS_ThrowTypeError(ctx, "%s", err_message.utf8().get_data());
 	}
@@ -478,7 +478,7 @@ Dictionary QuickJSBinder::js_to_dictionary(JSContext *ctx, const JSValue &p_val,
 					uint64_t i;
 				} u;
 				u.p = ptr;
-				ERR_PRINTS(vformat("Property '%s' circular reference to 0x%X", E->get(), u.i));
+				ERR_PRINT(vformat("Property '%s' circular reference to 0x%X", E->get(), u.i));
 				JS_FreeValue(ctx, v);
 				continue;
 			} else {
@@ -1307,10 +1307,10 @@ void QuickJSBinder::initialize() {
 				String address = E->next()->get();
 				Error err = debugger->connect(ctx, address);
 				if (err != OK) {
-					ERR_PRINTS(vformat("Failed to connect to JavaScript debugger at %s", address));
+					ERR_PRINT(vformat("Failed to connect to JavaScript debugger at %s", address));
 				}
 			} else {
-				ERR_PRINTS("Invalid debugger address");
+				ERR_PRINT("Invalid debugger address");
 			}
 		} else if (List<String>::Element *E = args.find("--js-debugger-listen")) {
 			if (E->next() && E->next()->get().find(":") != -1) {
@@ -1319,10 +1319,10 @@ void QuickJSBinder::initialize() {
 				if (err == OK) {
 					print_line(vformat("JavaScript debugger started at %s", address));
 				} else {
-					ERR_PRINTS(vformat("Failed to start JavaScript debugger at %s", address));
+					ERR_PRINT(vformat("Failed to start JavaScript debugger at %s", address));
 				}
 			} else {
-				ERR_PRINTS("Invalid debugger address");
+				ERR_PRINT("Invalid debugger address");
 			}
 		} else if (default_server_enabled) {
 			String address = vformat("0.0.0.0:%d", default_port);
@@ -1330,7 +1330,7 @@ void QuickJSBinder::initialize() {
 			if (err == OK) {
 				print_line(vformat("JavaScript debugger started at %s", address));
 			} else {
-				ERR_PRINTS(vformat("Failed to start JavaScript debugger at %s", address));
+				ERR_PRINT(vformat("Failed to start JavaScript debugger at %s", address));
 			}
 		}
 	} else {
@@ -1458,7 +1458,7 @@ void QuickJSBinder::frame() {
 				ECMAscriptScriptError script_err;
 				JSValue e = JS_GetException(ctx1);
 				dump_exception(ctx1, e, &script_err);
-				ERR_PRINTS(error_to_string(script_err));
+				ERR_PRINT(error_to_string(script_err));
 				JS_FreeValue(ctx1, e);
 			}
 			break;
@@ -1484,7 +1484,7 @@ void QuickJSBinder::frame() {
 			JSValue e = JS_GetException(ctx);
 			ECMAscriptScriptError err;
 			dump_exception(ctx, e, &err);
-			ERR_PRINTS("Error in requestAnimationFrame:" ENDL + error_to_string(err));
+			ERR_PRINT("Error in requestAnimationFrame:" ENDL + error_to_string(err));
 			JS_FreeValue(ctx, e);
 		}
 		id = frame_callbacks.next(id);
@@ -1499,7 +1499,7 @@ Error QuickJSBinder::eval_string(const String &p_source, EvalType type, const St
 	String error;
 	Error err = safe_eval_text(p_source, type, p_path, error, r_ret);
 	if (err != OK && !error.empty()) {
-		ERR_PRINTS(error);
+		ERR_PRINT(error);
 	}
 	return err;
 }
@@ -1717,7 +1717,7 @@ void QuickJSBinder::initialize_properties(JSContext *ctx, const ECMAClassInfo *p
 			ECMAscriptScriptError error;
 			dump_exception(ctx, e, &error);
 			JS_FreeValue(ctx, e);
-			ERR_PRINTS(vformat("Cannot initialize property '%s' of class '%s'\n%s", *prop_name, p_class->class_name, binder->error_to_string(error)));
+			ERR_PRINT(vformat("Cannot initialize property '%s' of class '%s'\n%s", *prop_name, p_class->class_name, binder->error_to_string(error)));
 		}
 		JS_FreeAtom(ctx, pname);
 		prop_name = p_class->properties.next(prop_name);
@@ -2005,7 +2005,7 @@ Error QuickJSBinder::define_operators(JSContext *ctx, JSValue p_prototype, JSVal
 		JSValue e = JS_GetException(ctx);
 		dump_exception(ctx, e, &error);
 		JS_FreeValue(ctx, e);
-		ERR_PRINTS(binder->error_to_string(error));
+		ERR_PRINT(binder->error_to_string(error));
 		return FAILED;
 	}
 	JS_DefinePropertyValue(ctx, p_prototype, JS_ATOM_Symbol_operatorSet, operators, PROP_DEF_DEFAULT);
@@ -2013,8 +2013,10 @@ Error QuickJSBinder::define_operators(JSContext *ctx, JSValue p_prototype, JSVal
 }
 
 JSValue QuickJSBinder::godot_set_script_meta(JSContext *ctx, JSValue this_val, int argc, JSValue *argv, int magic) {
-	ERR_FAIL_COND_V(argc < 2, JS_ThrowTypeError(ctx, "Two or more arguments expected"))
-	ERR_FAIL_COND_V(!JS_IsFunction(ctx, argv[0]), JS_ThrowTypeError(ctx, "godot class expected for argument #0"));
+	
+	// ERR_FAIL_COND_V(argc < 2, JS_ThrowTypeError(ctx, "Two or more arguments expected"))
+	// ERR_FAIL_COND_V(!JS_IsFunction(ctx, argv[0]), JS_ThrowTypeError(ctx, "godot class expected for argument #0"));
+
 	JSValue constructor = argv[0];
 	QuickJSBinder *binder = get_context_binder(ctx);
 	switch (magic) {
@@ -2123,7 +2125,7 @@ Variant QuickJSBinder::call_method(const ECMAScriptGCHandler &p_object, const St
 		JSValue exception = JS_GetException(ctx);
 		ECMAscriptScriptError err;
 		dump_exception(ctx, exception, &err);
-		ERR_PRINTS(error_to_string(err));
+		ERR_PRINT(error_to_string(err));
 		JS_Throw(ctx, exception);
 	} else {
 		r_error.error = Variant::CallError::CALL_OK;
@@ -2214,7 +2216,7 @@ const ECMAClassInfo *QuickJSBinder::parse_ecma_class_from_module(ModuleCache *p_
 	}
 	if (!JS_IsFunction(ctx, default_entry)) {
 		String err = "Failed parse ECMAClass from script " + p_path + ENDL "\t" + "Default export entry must be a godot class!";
-		ERR_PRINTS(err);
+		ERR_PRINT(err);
 		JS_ThrowTypeError(ctx, "%s", err.utf8().get_data());
 		goto fail;
 	}

--- a/quickjs/quickjs_worker.cpp
+++ b/quickjs/quickjs_worker.cpp
@@ -36,7 +36,7 @@ void QuickJSWorker::thread_main(void *p_this) {
 							JSValue e = JS_GetException(self->ctx);
 							ECMAscriptScriptError err;
 							dump_exception(self->ctx, e, &err);
-							ERR_PRINTS(String("Error in worker onmessage callback") + ENDL + self->error_to_string(err));
+							ERR_PRINT(String("Error in worker onmessage callback") + ENDL + self->error_to_string(err));
 							JS_FreeValue(self->ctx, e);
 						}
 						JS_FreeValue(self->ctx, argv[0]);
@@ -46,10 +46,10 @@ void QuickJSWorker::thread_main(void *p_this) {
 			}
 			JS_FreeValue(self->ctx, onmessage_callback);
 		} else {
-			ERR_PRINTS("Failed to eval entry script:" + self->entry_script + "\nError:" + err_text);
+			ERR_PRINT("Failed to eval entry script:" + self->entry_script + "\nError:" + err_text);
 		}
 	} else {
-		ERR_PRINTS("Failed to load entry script:" + self->entry_script);
+		ERR_PRINT("Failed to load entry script:" + self->entry_script);
 	}
 
 	self->uninitialize();
@@ -138,7 +138,7 @@ bool QuickJSWorker::frame_of_host(QuickJSBinder *host, const JSValueConst &value
 				JSValue e = JS_GetException(host->ctx);
 				ECMAscriptScriptError err;
 				dump_exception(host->ctx, e, &err);
-				ERR_PRINTS(String("Error in worker onmessage callback") + ENDL + error_to_string(err));
+				ERR_PRINT(String("Error in worker onmessage callback") + ENDL + error_to_string(err));
 				JS_FreeValue(host->ctx, e);
 			}
 			JS_FreeValue(host->ctx, argv[0]);


### PR DESCRIPTION
1. ERR_PRINTS
- 替换成`ERR_PRINT`


2. ECMAScript
```c++
// 3.4未知应用
bool inherits_script(const Ref<Script> &p_script) const;

bool ECMAScript::inherits_script(const Ref<Script> &p_script) const {
	return false;
}
```

3. ECMAScriptLanguage
```c++
virtual bool is_control_flow_keyword(String p_keywords) const;
// 控制流关键词
bool ECMAScriptLanguage::is_control_flow_keyword(String p_keyword) const {
	return p_keyword == "break" ||
			p_keyword == "continue" ||
			p_keyword == "if" ||
			p_keyword == "else" ||
			p_keyword == "for" ||
			p_keyword == "switch" ||
			p_keyword == "default" ||
			p_keyword == "return" ||
			p_keyword == "while";
}
```


4. QuickJSBinder
```c++
JSValue QuickJSBinder::godot_set_script_meta(JSContext *ctx, JSValue this_val, int argc, JSValue *argv, int magic) {
    // 注释掉 报错的
	// ERR_FAIL_COND_V(argc < 2, JS_ThrowTypeError(ctx, "Two or more arguments expected"))
	// ERR_FAIL_COND_V(!JS_IsFunction(ctx, argv[0]), JS_ThrowTypeError(ctx, "godot class expected for argument #0"));
```